### PR TITLE
Fix encoding issue with image copy script

### DIFF
--- a/scripts/enterprise/copy-master-image-azure.ps1
+++ b/scripts/enterprise/copy-master-image-azure.ps1
@@ -28,13 +28,13 @@ if (!$destBlob) {$destBlob = $destBlobDefault}
 
 # copy master blob to images
 $sourceStorageContext = New-AzureStorageContext `
-    –StorageAccountName $storageAccountName `
+    -StorageAccountName $storageAccountName `
     -StorageAccountKey $storageAccountKey
  
 if ($destinationStorageAccountName) {
  
     $destinationStorageContext = New-AzureStorageContext `
-        –StorageAccountName $destinationStorageAccountName `
+        -StorageAccountName $destinationStorageAccountName `
         -StorageAccountKey $destinationAccountKey
 }
 else {


### PR DESCRIPTION
This replaces a couple dash characters that aren't recognized after generating the script.